### PR TITLE
Enhance build action with GitHub releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -34,12 +34,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
-          components: rustfmt
       - name: Clippy
         uses: actions-rs/clippy-check@v1
         with:
@@ -51,3 +50,31 @@ jobs:
           cargo build
       - name: Run tests
         run: cargo test --verbose
+
+  dev-release:
+    name: Create pre-release
+    if: github.ref == 'refs/heads/main' && !contains(github.ref, 'tags/v')
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Create pre-release
+        uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          prerelease: true
+          title: "Development Build"
+
+  release:
+    name: Create release
+    if: contains(github.ref, 'tags/v')
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Create release
+        uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false


### PR DESCRIPTION
We need to start versioning the API model for easy inclusion into integration projects.

- Automatically create a GitHub pre-release for pushes on main branch.
- Automatically create a GitHub release for version tags (starting with v).
- A GitHub release changelog is automatically created based on the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format, which we have been using in our old projects.  
  We can discuss using the manual [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format as I suggested for the [Core-API changelog PR](https://github.com/unfoldedcircle/core-api/pull/21) and change it later.

Closes #1