### PR TITLE
Reconfigure flag for driver setup request

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "uc_api"
-version = "0.8.3-alpha"
+version = "0.8.4-beta"
 authors = ["Markus Zehnder <markus.z@unfoldedcircle.com>"]
 license = "Apache-2.0"
 description = "Unfolded Circle API model"
 edition = "2021"
 repository = "https://github.com/unfoldedcircle/api-model-rs"
+rust-version = "1.62"
 
 [dependencies]
 # JSON (de)serialization
@@ -16,8 +17,8 @@ serde_with = "3"
 chrono = { version = "0.4" , features = ["serde"] }
 
 # Helpful macros for working with enums and strings
-strum = "0.24"
-strum_macros = "0.24"
+strum = "0.25"
+strum_macros = "0.25"
 derive_more = "0.99"
 
 validator = "0.16"

--- a/src/intg/mod.rs
+++ b/src/intg/mod.rs
@@ -100,9 +100,20 @@ pub struct IntegrationDriverInfo {
     pub driver_state: Option<DriverState>,
 }
 
-/// Message data payload of `setup_driver`.
+/// Message data payload of `setup_driver` to start driver setup.
+///
+/// If a driver includes a `setup_data_schema` object in its driver metadata, it
+/// enables the dynamic driver setup process. The setup process can be a simple
+/// "start-confirm-done" between the Remote Two and the integration driver, or a fully
+/// dynamic, multistep process with user interactions, where the user has to provide
+/// additional data or select different options.
+#[skip_serializing_none]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SetupDriver {
+    /// Flag to distinguish regular driver setup vs. driver reconfiguration.
+    pub reconfigure: Option<bool>,
+    /// Input values of the initial setup page if it contains input fields and not just text.
+    /// The key is the input field identifier, value contains the input value.
     pub setup_data: HashMap<String, String>,
 }
 
@@ -189,7 +200,6 @@ pub struct IntegrationDriver {
     /// Number of integration instances.
     pub instance_count: Option<u16>,
     /// Driver configuration metadata describing configuration parameters for the web-configurator.
-    /// **Not yet finalized**.
     #[cfg(feature = "sqlx")]
     pub setup_data_schema: Json<Value>,
     #[cfg(not(feature = "sqlx"))]


### PR DESCRIPTION
Add a `reconfigure` flag in `SetupDriver` to indicate a driver reconfiguration.
Added in Integration-API v0.8.0-beta
