### PR TITLE
fix: driver_version response data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uc_api"
-version = "0.9.0-beta"
+version = "0.9.1-beta"
 authors = ["Markus Zehnder <markus.z@unfoldedcircle.com>"]
 license = "Apache-2.0"
 description = "Unfolded Circle API model"

--- a/src/intg/mod.rs
+++ b/src/intg/mod.rs
@@ -31,7 +31,7 @@ pub struct IntegrationVersion {
     /// Implemented API version.
     pub api: Option<String>,
     /// Version of the integration.
-    pub integration: Option<String>,
+    pub driver: Option<String>,
 }
 
 /// Subscribe to events.

--- a/src/intg/ws/mod.rs
+++ b/src/intg/ws/mod.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use strum_macros::*;
 use validator::Validate;
 
-use crate::intg::{AvailableIntgEntity, DeviceState};
+use crate::intg::{AvailableIntgEntity, DeviceState, IntegrationVersion};
 use crate::EntityType;
 
 /// Remote Two initiated request messages for the integration driver.
@@ -104,6 +104,15 @@ pub enum DriverEvent {
     EntityAvailable,
     EntityRemoved,
     DriverSetupChange,
+}
+
+/// Payload data of a `driver_version` response message in `msg_data` property.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DriverVersionMsgData {
+    /// Only required for multi-device integrations.
+    pub name: Option<String>,
+    pub version: Option<IntegrationVersion>,
 }
 
 /// Payload data of a `device_state` event message in `msg_data` property.  


### PR DESCRIPTION
The driver version string must be returned in field `driver`.

This will create a new patch release 0.9.1-beta