### PR TITLE
Integration remote-entity support

### DIFF
--- a/src/core/entity.rs
+++ b/src/core/entity.rs
@@ -1,0 +1,25 @@
+// Copyright (c) 2024 Unfolded Circle ApS and contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Core-API related entity data structures.
+
+use serde::{Deserialize, Serialize};
+use strum_macros::{AsRefStr, Display, EnumString, VariantNames};
+
+/// Core-API remote entity option fields.
+///
+/// Attention: only valid in the Core-API data model. See [crate::intg::IntgRemoteOptionField]
+/// for the Integration-API data model.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[derive(AsRefStr, Display, EnumString, VariantNames)] // strum_macros
+#[strum(serialize_all = "snake_case")]
+pub enum RemoteOptionField {
+    Editable,
+    /// List of command identifiers which can be used in the `send` command.
+    ///
+    /// For an IR remote these are the IR command keys of the associated or learned IR dataset.
+    SimpleCommands,
+    ButtonMapping,
+    UserInterface,
+}

--- a/src/core/entity.rs
+++ b/src/core/entity.rs
@@ -23,3 +23,41 @@ pub enum RemoteOptionField {
     ButtonMapping,
     UserInterface,
 }
+
+/// Core-API remote features.
+///
+/// Attention: only valid in the Core-API data model. See [crate::intg::IntgRemoteFeature]
+/// for the Integration-API data model.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[derive(AsRefStr, Display, EnumString, VariantNames)] // strum_macros
+#[strum(serialize_all = "snake_case")]
+pub enum RemoteFeature {
+    OnOff,
+    Toggle,
+    /// Send IR commands
+    Send,
+    /// Stop sending a repeated IR command
+    StopSend,
+    /// Send arbitrary commands
+    SendCmd,
+}
+
+/// Core-API remote entity commands.
+///
+/// Attention: only valid in the Core-API data model. See [crate::intg::IntgRemoteCommand]
+/// for the Integration-API data model.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[derive(AsRefStr, Display, EnumString, VariantNames)] // strum_macros
+#[strum(serialize_all = "snake_case")]
+pub enum RemoteCommand {
+    On,
+    Off,
+    Toggle,
+    Send,
+    StopSend,
+    SendSequence,
+    SendCmd,
+    SendCmdSequence,
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -7,4 +7,7 @@
 //!
 //! TODO data structures will be published after Core API is public.
 
+mod entity;
 pub mod web;
+
+pub use entity::*;

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -30,7 +30,6 @@ pub enum EntityType {
     Activity,
     /// Internal entity only at the moment
     Macro,
-    /// Internal entity only at the moment
     Remote,
 }
 
@@ -625,6 +624,15 @@ pub enum RemoteCommand {
     Send,
     StopSend,
     SendSequence,
+}
+
+/// Remote entity attributes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[derive(AsRefStr, Display, EnumString, VariantNames)] // strum_macros
+#[strum(serialize_all = "snake_case")]
+pub enum RemoteAttribute {
+    State,
 }
 
 #[cfg(test)]

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -93,12 +93,12 @@ pub enum SwitchDeviceClass {
     Switch,
 }
 
-/// Switch entity options.
+/// Switch entity option fields.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[derive(AsRefStr, Display, EnumString, VariantNames)] // strum_macros
 #[strum(serialize_all = "snake_case")]
-pub enum SwitchOption {
+pub enum SwitchOptionField {
     Readable,
 }
 
@@ -126,12 +126,12 @@ pub enum ClimateFeature {
     //Fan Not yet implemented
 }
 
-/// Climate entity options.
+/// Climate entity option fields.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[derive(AsRefStr, Display, EnumString, VariantNames)] // strum_macros
 #[strum(serialize_all = "snake_case")]
-pub enum ClimateOption {
+pub enum ClimateOptionField {
     /// The unit of temperature measurement: `CELSIUS`, `FAHRENHEIT`.
     /// If not specified, the remote settings are used.
     TemperatureUnit,
@@ -251,12 +251,12 @@ pub enum LightCommand {
     Toggle,
 }
 
-/// Light entity options.
+/// Light entity option fields.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[derive(AsRefStr, Display, EnumString, VariantNames)] // strum_macros
 #[strum(serialize_all = "snake_case")]
-pub enum LightOption {
+pub enum LightOptionField {
     ColorTemperatureSteps,
 }
 
@@ -443,12 +443,12 @@ pub enum MediaPlayerDeviceClass {
     TV,
 }
 
-/// Media player entity options.
+/// Media player entity option fields.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[derive(AsRefStr, Display, EnumString, VariantNames)] // strum_macros
 #[strum(serialize_all = "snake_case")]
-pub enum MediaPlayerOption {
+pub enum MediaPlayerOptionField {
     /// Additional commands the media-player supports, which are not covered in the feature list.
     SimpleCommands,
     /// Number of available volume steps for the set volume command and UI controls.
@@ -506,12 +506,12 @@ pub enum MediaPlayerAttribute {
     SoundModeList,
 }
 
-/// Sensor entity options.
+/// Sensor entity option fields.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[derive(AsRefStr, Display, EnumString, VariantNames)] // strum_macros
 #[strum(serialize_all = "snake_case")]
-pub enum SensorOption {
+pub enum SensorOptionField {
     /// Label for a custom sensor if `device_class` is not specified or to override a default unit.
     CustomLabel,
     /// Unit label for a custom sensor if `device_class` is not specified or to override a default

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -600,32 +600,6 @@ pub enum MacroCommand {
     Run,
 }
 
-/// Remote features.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-#[derive(AsRefStr, Display, EnumString, VariantNames)] // strum_macros
-#[strum(serialize_all = "snake_case")]
-pub enum RemoteFeature {
-    OnOff,
-    Toggle,
-    Send,
-    StopSend,
-}
-
-/// Remote entity commands.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-#[derive(AsRefStr, Display, EnumString, VariantNames)] // strum_macros
-#[strum(serialize_all = "snake_case")]
-pub enum RemoteCommand {
-    On,
-    Off,
-    Toggle,
-    Send,
-    StopSend,
-    SendSequence,
-}
-
 /// Remote entity attributes.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/src/intg/entity.rs
+++ b/src/intg/entity.rs
@@ -108,7 +108,7 @@ pub struct AvailableIntgEntity {
 #[strum(serialize_all = "snake_case")]
 pub enum IntgRemoteOptionField {
     /// Supported commands of the remote.
-    SupportedCommands,
+    SimpleCommands,
 }
 
 /// Integration-APU remote features.

--- a/src/intg/entity.rs
+++ b/src/intg/entity.rs
@@ -110,3 +110,33 @@ pub enum IntgRemoteOptionField {
     /// Supported commands of the remote.
     SupportedCommands,
 }
+
+/// Integration-APU remote features.
+///
+/// Attention: only valid in the Integration-API data model. See [crate::core::RemoteFeature]
+/// for the Core-API data model.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[derive(AsRefStr, Display, EnumString, VariantNames)] // strum_macros
+#[strum(serialize_all = "snake_case")]
+pub enum IntgRemoteFeature {
+    OnOff,
+    Toggle,
+    SendCmd,
+}
+
+/// Integration-API remote entity commands.
+///
+/// Attention: only valid in the Integration-API data model. See [crate::core::RemoteCommand]
+/// for the Core-API data model.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[derive(AsRefStr, Display, EnumString, VariantNames)] // strum_macros
+#[strum(serialize_all = "snake_case")]
+pub enum IntgRemoteCommand {
+    On,
+    Off,
+    Toggle,
+    SendCmd,
+    SendCmdSequence,
+}

--- a/src/intg/entity.rs
+++ b/src/intg/entity.rs
@@ -109,6 +109,10 @@ pub struct AvailableIntgEntity {
 pub enum IntgRemoteOptionField {
     /// Supported commands of the remote.
     SimpleCommands,
+    /// Optional command mapping for the physical buttons.
+    ButtonMapping,
+    /// Optional user interface definition for the supported commands.
+    UserInterface,
 }
 
 /// Integration-APU remote features.

--- a/src/intg/entity.rs
+++ b/src/intg/entity.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::skip_serializing_none;
+use strum_macros::{AsRefStr, Display, EnumString, VariantNames};
 
 use crate::{EntityType, REGEX_ID_CHARS};
 
@@ -95,4 +96,17 @@ pub struct AvailableIntgEntity {
     /// for the entity setup process. Otherwise defaults are used (e.g. `state=UNKNOWN`).   
     /// See entity documentation for available attributes.
     pub attributes: Option<serde_json::Map<String, Value>>,
+}
+
+/// Integration-API remote entity option fields.
+///
+/// Attention: only valid in the Integration-API data model. See [crate::core::RemoteOptionField]
+/// for the Core-API data model.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[derive(AsRefStr, Display, EnumString, VariantNames)] // strum_macros
+#[strum(serialize_all = "snake_case")]
+pub enum IntgRemoteOptionField {
+    /// Supported commands of the remote.
+    SupportedCommands,
 }


### PR DESCRIPTION
Add support for the new integration remote-entity.
Based on Core-API enhancement https://github.com/unfoldedcircle/core-api/pull/44

Other changes:
- Refactor remote enums into core & integration versions
- Rename entity option enums: add `Field` suffix to make it clear that the enum is for the option field names.