### PR TITLE
ci: update GitHub actions

### DIFF
--- a/.github/workflows/audit-on-push.yml
+++ b/.github/workflows/audit-on-push.yml
@@ -3,10 +3,27 @@ on:
   push:
     paths:
       - '**/Cargo.toml'
+      - '.github/**/audit-on-push.yml'
 jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
+
+      - name: Cache cargo-bin
+        id: cache-dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin
+          key: ${{ runner.os }}-cargo-bin
+
+      - name: Install cargo audit
+        shell: bash
+        run: |
+          if [[ ! -x "$(command -v cargo-audit)" ]]; then
+            echo "cargo-audit not found, installing it with cargo"
+            cargo install --force cargo-audit
+          fi;
 
       - run: cargo audit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - '**/Cargo.toml'
       - 'src/**'
-      - '.github/**/*.yml'
+      - '.github/**/build.yml'
   pull_request:
     branches: [ main ]
     types: [ opened, synchronize, reopened ]
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -52,12 +52,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "lts/*"
 
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
 
       - name: Extract archives from downloaded artifacts
         run: |
@@ -100,7 +100,7 @@ jobs:
 
       # Checkout is required for the next `gh release delete` step
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: main
 


### PR DESCRIPTION
Install and cache cargo audit, no longer available in runner image.