### PR TITLE
build: dependency update, Rust edition 2024 

### DIFF
--- a/.run/All Tests.run.xml
+++ b/.run/All Tests.run.xml
@@ -1,7 +1,9 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="All Tests" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+    <option name="buildProfileId" value="test" />
     <option name="command" value="test" />
     <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+    <envs />
     <option name="emulateTerminal" value="false" />
     <option name="channel" value="DEFAULT" />
     <option name="requiredFeatures" value="true" />
@@ -9,7 +11,6 @@
     <option name="withSudo" value="false" />
     <option name="buildTarget" value="REMOTE" />
     <option name="backtrace" value="SHORT" />
-    <envs />
     <option name="isRedirectInput" value="false" />
     <option name="redirectInputPath" value="" />
     <method v="2">

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.13.0"
 authors = ["Markus Zehnder <markus.z@unfoldedcircle.com>"]
 license = "Apache-2.0"
 description = "Unfolded Circle API model"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/unfoldedcircle/api-model-rs"
-rust-version = "1.70"
+rust-version = "1.85"
 
 [dependencies]
 # JSON (de)serialization
@@ -18,14 +18,13 @@ chrono = { version = "0.4", features = ["serde"] }
 url = { version = "2", features = ["serde"] }
 
 # Helpful macros for working with enums and strings
-strum = "0.26"
-strum_macros = "0.26"
-derive_more = "0.99"
+strum = "0.27"
+strum_macros = "0.27"
 
-validator = "0.16"
-validator_derive = "0.16"
+validator = "0.20"
+validator_derive = "0.20"
 regex = "1"
-lazy_static = "1"
+once_cell = "1"
 
 [dependencies.sqlx]
 # ATTENTION: 0.6.x versions are broken! Compilation takes forever and uses massive amounts of RAM. At 30 GB I killed it...

--- a/src/intg/entity.rs
+++ b/src/intg/entity.rs
@@ -66,11 +66,11 @@ pub struct AvailableIntgEntity {
         code = "INVALID_LENGTH",
         message = "Invalid length (min = 1, max = 36)"
     ))]
-    #[validate(regex(path = "REGEX_ID_CHARS"))]
+    #[validate(regex(path = "*REGEX_ID_CHARS"))]
     pub entity_id: String,
     /// Optional associated device, only if the integration driver supports multiple devices.
     #[validate(length(max = 36, message = "Invalid length (max = 36)"))]
-    #[validate(regex(path = "REGEX_ID_CHARS"))]
+    #[validate(regex(path = "*REGEX_ID_CHARS"))]
     pub device_id: Option<String>,
     /// Discriminator value for the concrete entity device type.
     pub entity_type: EntityType,

--- a/src/intg/mod.rs
+++ b/src/intg/mod.rs
@@ -220,7 +220,7 @@ pub struct IntegrationDriver {
 pub struct IntegrationDriverUpdate {
     /// Integration driver identifier.  
     #[validate(length(max = 36, message = "Invalid length (max = 36)"))]
-    #[validate(regex(path = "REGEX_ID_CHARS"))]
+    #[validate(regex(path = "*REGEX_ID_CHARS"))]
     pub driver_id: Option<String>,
     // TODO validate HashMap with custom validation function?
     pub name: Option<HashMap<String, String>>,
@@ -240,7 +240,7 @@ pub struct IntegrationDriverUpdate {
     pub icon: Option<String>,
     pub enabled: Option<bool>,
     pub description: Option<HashMap<String, String>>,
-    #[validate]
+    #[validate(nested)]
     pub developer: Option<DriverDeveloper>,
     #[validate(url)]
     #[validate(length(max = 255, message = "Invalid length (max = 255)"))]
@@ -297,7 +297,7 @@ pub struct DriverDeveloper {
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize, Validate)]
 pub struct DriverManifest {
     /// Required features of an integration driver.
-    #[validate]
+    #[validate(nested)]
     #[validate(length(min = 1))]
     pub features: Option<Vec<DriverFeature>>,
     pub iot_class: Option<IotClass>,
@@ -409,12 +409,12 @@ pub struct IntegrationUpdate {
     /// Only required for multi-device integrations.
     /// This field cannot be updated.
     #[validate(length(max = 36, message = "Invalid length (max = 36)"))]
-    #[validate(regex(path = "REGEX_ID_CHARS", code = "INVALID_CHARACTERS"))]
+    #[validate(regex(path = "*REGEX_ID_CHARS", code = "INVALID_CHARACTERS"))]
     pub device_id: Option<String>,
     pub name: Option<HashMap<String, String>>,
     /// Optional icon identifier of the integration.
     #[validate(length(max = 255, message = "Invalid length (max = 255)"))]
-    #[validate(regex(path = "REGEX_ICON_ID", code = "INVALID_CHARACTERS"))]
+    #[validate(regex(path = "*REGEX_ICON_ID", code = "INVALID_CHARACTERS"))]
     pub icon: Option<String>,
     pub enabled: Option<bool>,
     #[cfg(feature = "sqlx")]

--- a/src/intg/ws/mod.rs
+++ b/src/intg/ws/mod.rs
@@ -10,9 +10,9 @@ use strum_macros::*;
 use url::Url;
 use validator::Validate;
 
+use crate::EntityType;
 use crate::intg::{AvailableIntgEntity, DeviceState, IntegrationVersion};
 use crate::model::Oauth2Token;
-use crate::EntityType;
 
 /// Remote Two initiated request messages for the integration driver.
 ///

--- a/src/intg/ws/mod.rs
+++ b/src/intg/ws/mod.rs
@@ -187,7 +187,7 @@ pub struct AvailableEntitiesFilter {
 #[derive(Debug, Clone, Deserialize, Serialize, Validate)]
 pub struct AvailableEntitiesMsgData {
     pub filter: Option<AvailableEntitiesFilter>,
-    #[validate]
+    #[validate(nested)]
     pub available_entities: Vec<AvailableIntgEntity>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 #[macro_use]
 extern crate validator_derive;
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use regex::Regex;
 
 pub mod core;
@@ -50,8 +50,5 @@ pub mod ws;
 
 pub use entity::*;
 
-lazy_static! {
-    // max length is a dedicated validation for better error messages
-    static ref REGEX_ID_CHARS: Regex = Regex::new(r"^[a-zA-Z0-9-_]{1,}$").unwrap();
-    static ref REGEX_ICON_ID: Regex = Regex::new(r"^[a-zA-Z0-9-_\\.:]{1,}$").unwrap();
-}
+static REGEX_ID_CHARS: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[a-zA-Z0-9-_]{1,}$").unwrap());
+static REGEX_ICON_ID: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[a-zA-Z0-9-_\\.:]{1,}$").unwrap());

--- a/src/model/settings.rs
+++ b/src/model/settings.rs
@@ -29,7 +29,7 @@ pub struct SettingsPage {
     /// Language specific settings page title.
     pub title: HashMap<String, String>,
     /// One or multiple input field definitions, with optional pre-set values.
-    #[validate]
+    #[validate(nested)]
     pub settings: Vec<Setting>,
 }
 
@@ -160,7 +160,7 @@ pub struct Checkbox {
 pub struct Dropdown {
     /// Pre-selected dropdown id.
     pub value: Option<String>,
-    #[validate]
+    #[validate(nested)]
     pub items: Vec<DropdownItem>,
 }
 

--- a/src/ws/mod.rs
+++ b/src/ws/mod.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use serde_with::skip_serializing_none;
 use strum_macros::*;
 


### PR DESCRIPTION
Replace lazy-static with once-cell.

The sqlx crate cannot be updated yet. This requires major refactoring in other components, and the latest 0.8 needs to be tested first if it solves the memory regressions.